### PR TITLE
Add Extra Feature to multicollab.user.js

### DIFF
--- a/multicollab.user.js
+++ b/multicollab.user.js
@@ -14,7 +14,7 @@
 // Creates a button.
 var multColl       = document.createElement ('div');
 multColl.innerHTML = '<button id="CollabButton" type="button">'
-             	   + 'Multicollab</button>';
+             	   + 'Add Presets</button>';
 multColl.setAttribute ('id', 'ButtonContainer');
 document.body.appendChild (multColl);
 // Creates input field for adding new VM IPs

--- a/multicollab.user.js
+++ b/multicollab.user.js
@@ -17,13 +17,29 @@ multColl.innerHTML = '<button id="CollabButton" type="button">'
              	   + 'Multicollab</button>';
 multColl.setAttribute ('id', 'ButtonContainer');
 document.body.appendChild (multColl);
+// Creates input field for adding new VM IPs
+var addVM         = document.createElement ('div');
+addVM.innerHTML   = '<input type="text" name="VMIP" id="VMIP" placeholder="example.com:6004" />'
+		  + '<button id="AddTheVM" type="button">'
+		  + 'Add VM</button>';
+addVM.setAttribute ('id', 'ButtonTextboxContainer');
+document.body.appendChild (addVM);
+
 
 // Executes the function if the button is clicked.
 document.getElementById ("CollabButton").addEventListener (
     "click", multicoll, false
 );
 
+document.getElementById ("AddTheVM").addEventListener (
+	"click", multiadd, false
+);
+
 // The function that adds the user vms, more will be added to the function in the future.
 function multicoll() {
 	multicollab('malakas.ml:6004');
+}
+
+function multiadd() {
+	multicollab(document.getElementById("VMIP").value);
 }


### PR DESCRIPTION
This update adds a easier way to input custom VM IPs that you have that aren't on the User VM list or on the presets. This also changes the button's text from "multicollab" to "Add Presets" (all other values are left untouched.